### PR TITLE
Fix measurement date and datetime inserted from OMOPVital procedure.

### DIFF
--- a/MSSQL/OMOPLoader.sql
+++ b/MSSQL/OMOPLoader.sql
@@ -1140,8 +1140,8 @@ INSERT INTO dbo.[measurement]
       ,[operator_concept_id])
 
 Select distinct m.patient_num, m.encounter_num, substring(vital.i_loinc, 1, 50), 
-m.start_date meaure_date,   
-CAST(CONVERT(char(5), M.start_date, 108) as datetime) measure_time,
+convert(date, m.start_date) meaure_date,   
+M.start_date measure_time,
 '0', m.nval_num, substring(m.units_cd, 1, 50), substring(concat (tval_char, nval_num), 1, 50), 
 isnull(u.concept_id, '0'), isnull(vital.omop_sourcecode, '0'), isnull(vital.omop_sourcecode, '0'),
 '44818701', provider.provider_id, '0'


### PR DESCRIPTION
Fix the date and datetime fields inserted into the measurement table via the OMOPVital procedure